### PR TITLE
fix(webpack-module.config): path reference

### DIFF
--- a/packages/react-scripts/config/webpack-module.config.js
+++ b/packages/react-scripts/config/webpack-module.config.js
@@ -420,7 +420,7 @@ module.exports = function(webpackEnv, appPackage) {
                     let eslintConfig;
                     try {
                       eslintConfig = eslintCli.getConfigForFile(
-                        paths.appIndexJs
+                        paths.appModule
                       );
                     } catch (e) {
                       console.error(e);


### PR DESCRIPTION
Updating to the `path.appModule` reference allows us to use a custom ESLint config, mostly