### PR TITLE
chore: bump version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipt/sg1-module-scripts",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "description": "Custom react-scripts for building SG1 modules with Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I neglected to bump the version on my last PR and then I did a beta release for `3.4.1` without suffixing it with `-beta`, so now I need to bump the patch version again. :disappointed: Just ignore the branch name...