### PR TITLE
fix add cjs file extension to jest config

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -58,6 +58,7 @@ const moduleFileExtensions = [
   'json',
   'web.jsx',
   'jsx',
+  'cjs.js'
 ];
 
 // Resolve file paths in the same order as webpack

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipt/sg1-module-scripts",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Custom react-scripts for building SG1 modules with Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Signed-off-by: Jessica Lynn Kim <jessica.kim@shipt.com>

Adding `cjs.js` to jest paths to mitigate failing jest tests in circleci `sg1-coverage-module`.